### PR TITLE
feat: add template, description and androidx support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@
 - Easy to use.
 - Customization
     - [ ] Auto Pub Run after creation
-    - [ ] Template (app, package, package, plugin)
-    - [ ] Description
+    - [x] Template (app, package, package, plugin)
+    - [x] Description
     - [x] Organization Name
     - [x] Project Name
     - [x] Android Language
     - [x] iOS Language
-    - [ ] AndroidX Support
+    - [x] AndroidX Support
     - [x] Project Directory
 - GUI version of `flutter create` command.
 


### PR DESCRIPTION
I have added support for template type, description and AndroidX.

Description:
![Screenshot from 2020-06-18 06-41-52](https://user-images.githubusercontent.com/22827908/84983853-90dae580-b131-11ea-9657-4b6b736689ba.png)

Project Template:
![Screenshot from 2020-06-18 06-41-44](https://user-images.githubusercontent.com/22827908/84983839-8587ba00-b131-11ea-8bc3-95f9a79237dd.png)

Use AndroidX?
![Screenshot from 2020-06-18 06-41-56](https://user-images.githubusercontent.com/22827908/84983868-99cbb700-b131-11ea-9966-1123c4b77309.png)

Generated Command:
![Screenshot from 2020-06-18 06-56-28](https://user-images.githubusercontent.com/22827908/84983910-aea84a80-b131-11ea-9f50-9bb589bdfee2.png)


